### PR TITLE
Development Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ crashlytics-build.properties
 
 # (Desktop Service Store) Invisible File on MacOS
 .DS_Store
+
+# Development Folder
+/[Aa]ssets/[Dd]evelopment/*
+/[Aa]ssets/[Dd]evelopment.meta


### PR DESCRIPTION
##Changes

This `.gitignore` file has been changed to not track folder under the following name scheme:
- `~/[Aa]ssets/[Dd]evelopment`

This folder can allow us to add Scripts/Scenes/GameObjects etc, we use for testing and development but it will not be tracked by GIT and not appear on the GitHub.

Closes #31