### PR TITLE
Options Screen

### DIFF
--- a/Assets/Prefabs/GameSettings.prefab
+++ b/Assets/Prefabs/GameSettings.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4378722153310308809
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8800762926006880444}
+  - component: {fileID: 3102925268401530174}
+  m_Layer: 0
+  m_Name: GameSettings
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8800762926006880444
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4378722153310308809}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3102925268401530174
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4378722153310308809}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: de8ce797f3ef0406e9664a4f918a4630, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/GameSettings.prefab.meta
+++ b/Assets/Prefabs/GameSettings.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 350beba6590e54d4584f48305ff7a0a9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.18028292, g: 0.22571306, b: 0.30692118, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1382,63 +1382,6 @@ PrefabInstance:
       insertIndex: -1
       addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: ac0f525f502c84abf83dd57a5b56de54, type: 3}
---- !u!1001 &5864931428159501852
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.37674332
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.209569
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -1.6215448
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5574038025942418154, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
-      propertyPath: m_Name
-      value: AudioManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
 --- !u!1001 &6199976871708531813
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1508,7 +1451,6 @@ SceneRoots:
   - {fileID: 646999957430646347}
   - {fileID: 1121498768}
   - {fileID: 1829522087}
-  - {fileID: 5864931428159501852}
   - {fileID: 600952633}
   - {fileID: 314697451}
   - {fileID: 1688966669}

--- a/Assets/Scenes/StartScene.unity
+++ b/Assets/Scenes/StartScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028334, g: 0.22571336, b: 0.3069219, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -184,6 +184,63 @@ MonoBehaviour:
   m_ParentUI: {fileID: 0}
   sourceAsset: {fileID: 9197481963319205126, guid: ad39181c1f9c6487d9cd631100730d7a, type: 3}
   m_SortingOrder: 0
+--- !u!1001 &971376801
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.37674332
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.209569
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.6215448
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2785292113364763381, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5574038025942418154, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
+      propertyPath: m_Name
+      value: AudioManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 083e180eddb814cf184897fb272b45d8, type: 3}
 --- !u!1 &1189064319
 GameObject:
   m_ObjectHideFlags: 0
@@ -254,3 +311,4 @@ SceneRoots:
   m_Roots:
   - {fileID: 651808069}
   - {fileID: 1189064322}
+  - {fileID: 971376801}

--- a/Assets/Scenes/StartScene.unity
+++ b/Assets/Scenes/StartScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028292, g: 0.22571306, b: 0.30692118, a: 1}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -120,6 +120,39 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &202723358
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 202723359}
+  m_Layer: 0
+  m_Name: StartMenu
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &202723359
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 202723358}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 651808069}
+  - {fileID: 1189064322}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &651808068
 GameObject:
   m_ObjectHideFlags: 0
@@ -146,12 +179,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 651808068}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 202723359}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &651808070
 MonoBehaviour:
@@ -283,12 +316,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1189064319}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 202723359}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1189064323
 MonoBehaviour:
@@ -366,7 +399,6 @@ PrefabInstance:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 651808069}
-  - {fileID: 1189064322}
+  - {fileID: 202723359}
   - {fileID: 971376801}
   - {fileID: 2190520886947777684}

--- a/Assets/Scenes/StartScene.unity
+++ b/Assets/Scenes/StartScene.unity
@@ -305,6 +305,63 @@ MonoBehaviour:
   _optionMenuDocument: {fileID: 1189064321}
   MainMenu: {fileID: 651808068}
   OptionsMenu: {fileID: 1189064319}
+--- !u!1001 &2190520886947777684
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4378722153310308809, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_Name
+      value: GameSettings
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8800762926006880444, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 350beba6590e54d4584f48305ff7a0a9, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -312,3 +369,4 @@ SceneRoots:
   - {fileID: 651808069}
   - {fileID: 1189064322}
   - {fileID: 971376801}
+  - {fileID: 2190520886947777684}

--- a/Assets/Scenes/StartScene.unity
+++ b/Assets/Scenes/StartScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028292, g: 0.22571306, b: 0.30692118, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -7,7 +7,7 @@ namespace Scripts.Audio
 {
     public class AudioManager : MonoBehaviour
     {
-        public static AudioManager _instance;
+        private static AudioManager _instance;
         public AudioSource musicSource, sfxSource;
 
 

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -33,7 +33,7 @@ namespace Scripts.Audio
             LoadPlayerPrefs();
         }
         /// <summary>
-        /// 
+        /// Destoys any duplication
         /// </summary>
         private void SetInstance()
         {
@@ -82,7 +82,7 @@ namespace Scripts.Audio
         }
 
         /// <summary>
-        /// 
+        /// Sets music volume but also checks user dont go above or below limit
         /// </summary>
         public void SetMusicVolume(float volume)
         {
@@ -96,7 +96,7 @@ namespace Scripts.Audio
         }
 
         /// <summary>
-        /// 
+        /// Sets sfx volume but also checks user dont go above or below limit
         /// </summary>
         public void SetSFXVolume(float volume)
         {
@@ -111,7 +111,7 @@ namespace Scripts.Audio
 
         #region PlayerPrefs Method
         /// <summary>
-        /// 
+        /// Cheks player preferences
         /// </summary>
         public void CheckPlayerPrefs()
         {
@@ -125,7 +125,7 @@ namespace Scripts.Audio
             }
         }
         /// <summary>
-        /// 
+        /// Load player prefernces
         /// </summary>
         public void LoadPlayerPrefs()
         {

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -7,6 +7,7 @@ namespace Scripts.Audio
 {
     public class AudioManager : MonoBehaviour
     {
+        #region Class Variables
         private static AudioManager _instance;
         public AudioSource musicSource, sfxSource;
 
@@ -22,8 +23,19 @@ namespace Scripts.Audio
                 return _instance;
             }
         }
+        #endregion
 
+        #region Awake Methods
         private void Awake()
+        {
+            SetInstance();
+            CheckPlayerPrefs();
+            LoadPlayerPrefs();
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        private void SetInstance()
         {
             if (_instance == null)
             {
@@ -36,7 +48,9 @@ namespace Scripts.Audio
             }
         }
 
+        #endregion
 
+        #region AudioManager Methods
         /// <summary>
         /// Plays music by assigning the provided AudioClip to the music AudioSource and starting playback.
         /// This method is used to handle continuous music, such as theme songs or background loops.
@@ -66,8 +80,60 @@ namespace Scripts.Audio
             source.clip = clip;
             source.Play();
         }
-    }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public void SetMusicVolume(float volume)
+        {
+            if(volume < 0 || volume > 1)
+            {
+                throw new ArgumentOutOfRangeException("Volume value must be between 0 to 1");
+            }
+            _instance.musicSource.volume = volume;
+            PlayerPrefs.SetFloat("MusicVolume", volume);
+
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void SetSFXVolume(float volume)
+        {
+            if (volume < 0 || volume > 1)
+            {
+                throw new ArgumentOutOfRangeException("Volume value must be between 0 to 1");
+            }
+            _instance.sfxSource.volume = volume;
+            PlayerPrefs.SetFloat("SFXVolume", volume);
+        }
+        #endregion
+
+        #region PlayerPrefs Method
+        /// <summary>
+        /// 
+        /// </summary>
+        public void CheckPlayerPrefs()
+        {
+            if (PlayerPrefs.HasKey("MusicVolume") == false)
+            {
+                PlayerPrefs.SetFloat("MusicVolume", 1f);
+            }
+            if (PlayerPrefs.HasKey("SFXVolume") == false)
+            {
+                PlayerPrefs.SetFloat("SFXVolume", 1f);
+            }
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public void LoadPlayerPrefs()
+        {
+            _instance.sfxSource.volume = PlayerPrefs.GetFloat("SFXVolume");
+            _instance.musicSource.volume = PlayerPrefs.GetFloat("MusicVolume");
+        }
+        #endregion
+    }
 }
 
 

--- a/Assets/Scripts/Audio/AudioTrigger.cs
+++ b/Assets/Scripts/Audio/AudioTrigger.cs
@@ -16,9 +16,9 @@ namespace Scripts.Audio
             if (other.CompareTag("Player"))
             {
                 // Play the trigger sound using the AudioManager
-                if (AudioManager._instance != null)
+                if (AudioManager.Instance != null)
                 {
-                    AudioManager._instance.PlaySFX(_triggerSound);
+                    AudioManager.Instance.PlaySFX(_triggerSound);
                 }
 
                 // Mark the trigger box quest as complete

--- a/Assets/Scripts/Game.meta
+++ b/Assets/Scripts/Game.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8403017547cf840bc93add4667bc1074
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/GameSettings.cs
+++ b/Assets/Scripts/Game/GameSettings.cs
@@ -71,9 +71,9 @@ namespace Scripts.Game
         /// </summary>
         public void SetNPCSubtitleSpeed(float speed)
         {
-            if (speed < 1f || speed > 10f)
+            if (speed < 0.01f || speed > 0.1f)
             {
-                throw new ArgumentOutOfRangeException("Subtitle Speed value must be between 1 to 10");
+                throw new ArgumentOutOfRangeException("Subtitle Speed value must be between 0.01 to 0.1");
             }
             NPCSubtitleSpeed = speed;
             PlayerPrefs.SetFloat("NPCSubtitleSpeed", speed);

--- a/Assets/Scripts/Game/GameSettings.cs
+++ b/Assets/Scripts/Game/GameSettings.cs
@@ -71,7 +71,7 @@ namespace Scripts.Game
         /// </summary>
         public void SetNPCSubtitleSpeed(float speed)
         {
-            if (speed < 1 || speed > 10)
+            if (speed < 1f || speed > 10f)
             {
                 throw new ArgumentOutOfRangeException("Subtitle Speed value must be between 1 to 10");
             }

--- a/Assets/Scripts/Game/GameSettings.cs
+++ b/Assets/Scripts/Game/GameSettings.cs
@@ -33,7 +33,7 @@ namespace Scripts.Game
             LoadPlayerPrefs();
         }
         /// <summary>
-        /// 
+        /// Checks duplication
         /// </summary>
         private void SetInstance()
         {
@@ -53,7 +53,7 @@ namespace Scripts.Game
         #region GameSettings Methods
 
         /// <summary>
-        /// 
+        /// Sets camera sentivity ensuring user does not go above or below limit
         /// </summary>
         public void SetCameraSensitivity(float sensitivity)
         {
@@ -67,7 +67,7 @@ namespace Scripts.Game
         }
 
         /// <summary>
-        /// 
+        /// Sets NPC subtittle ensuring user does not go above or below limit
         /// </summary>
         public void SetNPCSubtitleSpeed(float speed)
         {
@@ -82,7 +82,7 @@ namespace Scripts.Game
 
         #region PlayerPrefs Method
         /// <summary>
-        /// 
+        /// Checks player preferences
         /// </summary>
         public void CheckPlayerPrefs()
         {
@@ -96,7 +96,7 @@ namespace Scripts.Game
             }
         }
         /// <summary>
-        /// 
+        /// Loads player preferences
         /// </summary>
         public void LoadPlayerPrefs()
         {

--- a/Assets/Scripts/Game/GameSettings.cs
+++ b/Assets/Scripts/Game/GameSettings.cs
@@ -1,0 +1,109 @@
+﻿using UnityEngine;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Scripts.Game
+{
+    public class GameSettings : MonoBehaviour
+    {
+        #region Class Variables
+        private static GameSettings _instance;
+        public float CameraSensitivity { get; private set; }
+        public float NPCSubtitleSpeed { get; private set; }
+
+        public static GameSettings Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    Debug.LogError("Game Settings is Null");
+                }
+                return _instance;
+            }
+        }
+        #endregion
+
+        #region Awake Methods
+        private void Awake()
+        {
+            SetInstance();
+            CheckPlayerPrefs();
+            LoadPlayerPrefs();
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        private void SetInstance()
+        {
+            if (_instance == null)
+            {
+                _instance = this;
+                DontDestroyOnLoad(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        #endregion
+
+        #region GameSettings Methods
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void SetCameraSensitivity(float sensitivity)
+        {
+            if (sensitivity < 0 || sensitivity > 1)
+            {
+                throw new ArgumentOutOfRangeException("Sensitivity value must be between 0 to 1");
+            }
+            CameraSensitivity = sensitivity;
+            PlayerPrefs.SetFloat("CameraSensitivity", sensitivity);
+
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void SetNPCSubtitleSpeed(float speed)
+        {
+            if (speed < 1 || speed > 10)
+            {
+                throw new ArgumentOutOfRangeException("Subtitle Speed value must be between 1 to 10");
+            }
+            NPCSubtitleSpeed = speed;
+            PlayerPrefs.SetFloat("NPCSubtitleSpeed", speed);
+        }
+        #endregion
+
+        #region PlayerPrefs Method
+        /// <summary>
+        /// 
+        /// </summary>
+        public void CheckPlayerPrefs()
+        {
+            if (PlayerPrefs.HasKey("CameraSensitivity") == false)
+            {
+                PlayerPrefs.SetFloat("CameraSensitivity", 0.5f);
+            }
+            if (PlayerPrefs.HasKey("NPCSubtitleSpeed") == false)
+            {
+                PlayerPrefs.SetFloat("NPCSubtitleSpeed", 1.5f);
+            }
+        }
+        /// <summary>
+        /// 
+        /// </summary>
+        public void LoadPlayerPrefs()
+        {
+            CameraSensitivity = PlayerPrefs.GetFloat("CameraSensitivity");
+            NPCSubtitleSpeed = PlayerPrefs.GetFloat("NPCSubtitleSpeed");
+        }
+        #endregion
+    }
+}
+

--- a/Assets/Scripts/Game/GameSettings.cs.meta
+++ b/Assets/Scripts/Game/GameSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de8ce797f3ef0406e9664a4f918a4630
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MainMenu/MainMenuScript.cs
+++ b/Assets/Scripts/MainMenu/MainMenuScript.cs
@@ -11,7 +11,7 @@ namespace Scripts.MainMenu
         [SerializeField] private UIDocument _mainMenuDocument;
         private Button _playButton;
         private Button _settingButton;
-        private Button _quitButton;
+        private Button _tutorialButton;
         public GameObject MainMenu;
         public GameObject OptionsMenu;
 
@@ -24,11 +24,11 @@ namespace Scripts.MainMenu
             VisualElement root = _mainMenuDocument.rootVisualElement;
             _playButton = root.Q<Button>("PlayButton");
             _settingButton = root.Q<Button>("SettingButton");
-            _quitButton = root.Q<Button>("QuitButton");
+            _tutorialButton = root.Q<Button>("TutorialButton");
 
             //set button clicked methods
             _playButton.clickable.clicked += PlayGame;
-            _quitButton.clickable.clicked += QuitGame;
+            _tutorialButton.clickable.clicked += TutorialScreen;
             _settingButton.clickable.clicked += OptionPress;
         }
 
@@ -43,10 +43,9 @@ namespace Scripts.MainMenu
         /// <summary>
         /// Quits the Game
         /// </summary>
-        private void QuitGame()
+        private void TutorialScreen()
         {
-            Debug.Log("QUIT");
-            Application.Quit();
+            Debug.Log("Tutorial");
         }
 
         /// <summary>

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -14,8 +14,9 @@ namespace Scripts.MainMenu
         [SerializeField] private UIDocument _optionMenuDocument;
         public GameObject MainMenu;
         public GameObject OptionsMenu;
-        private Button _backButton;
+        private Button _backButton, _applyChangesButton, _revertChangesButton;
         private SliderInt _musicSlider, _sfxSlider, _cameraSensitivitySlider;
+        private Label _musicVolumeLabel, _sfxVolumeLabel, __cameraSensitivityLabel;
         #endregion
 
         #region Enable Methods
@@ -25,8 +26,9 @@ namespace Scripts.MainMenu
         private void OnEnable()
         {
             GetMenuComponents();
+            SetInitialMenuComponentValues();
             SetMenuComponentEventMethods();
-            SetSliderValues();
+            DisableApplyRevertButtons();
         }
 
         /// <summary>
@@ -36,13 +38,20 @@ namespace Scripts.MainMenu
         {
             VisualElement root = _optionMenuDocument.rootVisualElement;
 
-            // set button fields
+            //Set button fields
             _backButton = root.Q<Button>("BackButton");
+            _applyChangesButton = root.Q<Button>("ApplyChangesButton");
+            _revertChangesButton = root.Q<Button>("RevertChangesButton");
 
-            //set slider fields
+            //Set slider fields
             _musicSlider = root.Q<SliderInt>("MusicSlider");
             _sfxSlider = root.Q<SliderInt>("SFXSlider");
             _cameraSensitivitySlider = root.Q<SliderInt>("CameraSensitivitySlider");
+
+            //Set slider labels
+            _musicVolumeLabel = root.Q<Label>("MusicVolumeLabel");
+            _sfxVolumeLabel = root.Q<Label>("SFXVolumeLabel");
+            __cameraSensitivityLabel = root.Q<Label>("CameraSensitivityLabel");
         }
 
         /// <summary>
@@ -52,38 +61,26 @@ namespace Scripts.MainMenu
         {
             //set button clicked methods
             _backButton.clickable.clicked += GoBack;
-
+            _applyChangesButton.clickable.clicked += UpdateSettings;
+            _revertChangesButton.clickable.clicked += RevertSettingsChanges;
             //set slider methods
-            _musicSlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetMusicValue));
-            _sfxSlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetSFXValue));
-            _cameraSensitivitySlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetCameraSensitivity));
-        }
-
-        /// <summary>
-        /// From Google AI Overview: In C#, a delegate is a type that acts as a reference to a method with a specific parameter list and return type.
-        /// </summary>
-        private delegate void SetSliderValueFunction(float value = -1);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        private void HandleSliderChange(float value, SetSliderValueFunction function)
-        {
-            if(value != -1 && function != null)
-            {
-                function(value);
-            }
-            
+            _musicSlider.RegisterValueChangedCallback(value => UpdateSliderValue(value.newValue, _musicVolumeLabel));
+            _sfxSlider.RegisterValueChangedCallback(value => UpdateSliderValue(value.newValue, _sfxVolumeLabel));
+            _cameraSensitivitySlider.RegisterValueChangedCallback(value => UpdateSliderValue(value.newValue, __cameraSensitivityLabel));
         }
 
         /// <summary>
         /// 
         /// </summary>
-        private void SetSliderValues()
+        private void SetInitialMenuComponentValues()
         {
             _musicSlider.value = Mathf.RoundToInt((AudioManager.Instance.musicSource.volume)*100);
             _sfxSlider.value = Mathf.RoundToInt((AudioManager.Instance.sfxSource.volume) * 100);
             _cameraSensitivitySlider.value = Mathf.RoundToInt((GameSettings.Instance.CameraSensitivity) * 100);
+
+            _musicVolumeLabel.text = _musicSlider.value.ToString();
+            _sfxVolumeLabel.text = _sfxSlider.value.ToString();
+            __cameraSensitivityLabel.text = _cameraSensitivitySlider.value.ToString();
         }
         #endregion
 
@@ -95,6 +92,58 @@ namespace Scripts.MainMenu
         {
             OptionsMenu.gameObject.SetActive(false);
             MainMenu.gameObject.SetActive(true);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void UpdateSliderValue(float value, Label label)
+        {
+            if (value != -1 && label != null)
+            {
+                label.text = value.ToString();
+                EnableApplyRevertButtons();
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void UpdateSettings()
+        {
+            SetMusicValue(_musicSlider.value);
+            SetSFXValue(_sfxSlider.value);
+            SetCameraSensitivity(_cameraSensitivitySlider.value);
+            DisableApplyRevertButtons();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void RevertSettingsChanges()
+        {
+            SetInitialMenuComponentValues();
+            DisableApplyRevertButtons();
+        }
+        #endregion
+
+        #region Apply/Revert Changes Methods
+        /// <summary>
+        /// 
+        /// </summary>
+        public void EnableApplyRevertButtons()
+        {
+            _applyChangesButton.SetEnabled(true);
+            _revertChangesButton.SetEnabled(true);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void DisableApplyRevertButtons()
+        {
+            _applyChangesButton.SetEnabled(false);
+            _revertChangesButton.SetEnabled(false);
         }
 
         /// <summary>

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -22,7 +22,7 @@ namespace Scripts.MainMenu
 
         #region Enable Methods
         /// <summary>
-        /// 
+        /// Calls all method when script is called upon
         /// </summary>
         private void OnEnable()
         {
@@ -33,7 +33,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Sets buttons and sliders from the option menu to a variable
         /// </summary>
         private void GetMenuComponents()
         {
@@ -60,7 +60,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Sets each button and slider to the appropiate method
         /// </summary>
         private void SetMenuComponentEventMethods()
         {
@@ -79,7 +79,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for resetting settings
         /// </summary>
         private void SetInitialMenuComponentValues()
         {
@@ -95,7 +95,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for checking if npc subtitle is enabled
         /// </summary>
         private void CheckEnabledNPCSubtitleSpeedButtons()
         {
@@ -131,7 +131,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for updating slider values
         /// </summary>
         private void UpdateSliderValue(float value, Label label)
         {
@@ -143,7 +143,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for increasing subtitle speed
         /// </summary>
         private void IncreaseNPCSubtitleSpeed()
         {
@@ -166,7 +166,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for decreasing subtitle speed
         /// </summary>
         private void DecreaseNPCSubtitleSpeed()
         {
@@ -189,7 +189,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for saving setting
         /// </summary>
         private void UpdateSettings()
         {
@@ -201,7 +201,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for revert button
         /// </summary>
         private void RevertSettingsChanges()
         {
@@ -212,7 +212,7 @@ namespace Scripts.MainMenu
 
         #region Apply/Revert Changes Methods
         /// <summary>
-        /// 
+        /// Method for enabling refund button
         /// </summary>
         public void EnableApplyRevertButtons()
         {
@@ -221,7 +221,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for disableing revert button
         /// </summary>
         public void DisableApplyRevertButtons()
         {
@@ -230,7 +230,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for setting SFX volume
         /// </summary>
         public void SetSFXValue(float volume)
         {
@@ -238,7 +238,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for setting music volume
         /// </summary>
         public void SetMusicValue(float volume)
         {
@@ -246,7 +246,7 @@ namespace Scripts.MainMenu
         }
 
         /// <summary>
-        /// 
+        /// Method for setting camera sensetivity
         /// </summary>
         public void SetCameraSensitivity(float sensitivity)
         {

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -26,8 +26,8 @@ namespace Scripts.MainMenu
         private void OnEnable()
         {
             GetMenuComponents();
-            SetInitialMenuComponentValues();
             SetMenuComponentEventMethods();
+            SetInitialMenuComponentValues();
             DisableApplyRevertButtons();
         }
 
@@ -74,9 +74,9 @@ namespace Scripts.MainMenu
         /// </summary>
         private void SetInitialMenuComponentValues()
         {
-            _musicSlider.value = Mathf.RoundToInt((AudioManager.Instance.musicSource.volume)*100);
-            _sfxSlider.value = Mathf.RoundToInt((AudioManager.Instance.sfxSource.volume) * 100);
-            _cameraSensitivitySlider.value = Mathf.RoundToInt((GameSettings.Instance.CameraSensitivity) * 100);
+            _musicSlider.SetValueWithoutNotify(Mathf.RoundToInt((AudioManager.Instance.musicSource.volume)*100));
+            _sfxSlider.SetValueWithoutNotify(Mathf.RoundToInt((AudioManager.Instance.sfxSource.volume) * 100));
+            _cameraSensitivitySlider.SetValueWithoutNotify(Mathf.RoundToInt((GameSettings.Instance.CameraSensitivity) * 100));
 
             _musicVolumeLabel.text = _musicSlider.value.ToString();
             _sfxVolumeLabel.text = _sfxSlider.value.ToString();

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -100,13 +100,22 @@ namespace Scripts.MainMenu
         private void CheckEnabledNPCSubtitleSpeedButtons()
         {
             float speed = float.Parse(_npcSubtitleSpeedLabel.text);
-            if (speed == 1f)
+            if (speed > 1f)
             {
                 _decreaseNPCSubtitleSpeed.SetEnabled(true);
             }
-            if (speed == 10f)
+            else
+            {
+                _decreaseNPCSubtitleSpeed.SetEnabled(false);
+            }
+
+            if (speed < 10f)
             {
                 _increaseNPCSubtitleSpeed.SetEnabled(true);
+            }
+            else
+            {
+                _increaseNPCSubtitleSpeed.SetEnabled(false);
             }
         }
         #endregion

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -3,29 +3,67 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
+using AudioManager = Scripts.Audio.AudioManager;
 
 namespace Scripts.MainMenu
 {
     public class OptionMenuScript : MonoBehaviour
     {
+        #region Class Variables
         [SerializeField] private UIDocument _optionMenuDocument;
         public GameObject MainMenu;
         public GameObject OptionsMenu;
-        private Button _BackButton;
+        private Button _backButton;
+        private Slider _musicSlider, _sfxSlider, _cameraSensitivitySlider;
+        #endregion
 
+        #region Enable Methods
         /// <summary>
-        /// Assigns back button and sets onclick method for it.
+        /// 
         /// </summary>
         private void OnEnable()
         {
-            VisualElement root = _optionMenuDocument.rootVisualElement;
-            _BackButton = root.Q<Button>("BackButton");
-
-            //set button clicked methods
-            _BackButton.clickable.clicked += GoBack;
-
+            GetMenuComponents();
+            SetMenuComponentEventMethods();
+            SetSliderValues();
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        private void GetMenuComponents()
+        {
+            VisualElement root = _optionMenuDocument.rootVisualElement;
+
+            // set button fields
+            _backButton = root.Q<Button>("BackButton");
+
+            //set slider fields
+            _musicSlider = root.Q<Slider>("MusicSlider");
+            _sfxSlider = root.Q<Slider>("SFXSlider");
+            _cameraSensitivitySlider = root.Q<Slider>("CameraSensitivitySlider");
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void SetMenuComponentEventMethods()
+        {
+            //set button clicked methods
+            _backButton.clickable.clicked += GoBack;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void SetSliderValues()
+        {
+            _musicSlider.value = AudioManager.Instance.musicSource.volume;
+            _sfxSlider.value = AudioManager.Instance.sfxSource.volume;
+        }
+        #endregion
+
+        #region UI Component Methods
         /// <summary>
         ///Enables main menu canvas but disables option menu canvas
         /// </summary>
@@ -35,5 +73,33 @@ namespace Scripts.MainMenu
             MainMenu.gameObject.SetActive(true);
         }
 
+        /// <summary>
+        /// 
+        /// </summary>
+        public void SetSFXValue()
+        {
+            float volume = _sfxSlider.value;
+            AudioManager.Instance.sfxSource.volume = volume / 100;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void SetMusicValue()
+        {
+            float volume = _musicSlider.value;
+            AudioManager.Instance.musicSource.volume = volume / 100;
+
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public void SetCameraSensitivity()
+        {
+            float sensitivity = _cameraSensitivitySlider.value;
+
+        }
+        #endregion
     }
 }

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -54,8 +54,8 @@ namespace Scripts.MainMenu
 
             //set slider methods
             _musicSlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetMusicValue));
-            _sfxSlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetMusicValue));
-            _cameraSensitivitySlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetMusicValue));
+            _sfxSlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetSFXValue));
+            _cameraSensitivitySlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetCameraSensitivity));
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Scripts.MainMenu
         /// </summary>
         public void SetSFXValue(float volume)
         {
-            AudioManager.Instance.sfxSource.volume = volume / 100;
+            AudioManager.Instance.SetSFXVolume(volume / 100);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Scripts.MainMenu
         /// </summary>
         public void SetMusicValue(float volume)
         {
-            AudioManager.Instance.musicSource.volume = volume / 100;
+            AudioManager.Instance.SetMusicVolume(volume / 100);
         }
 
         /// <summary>

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
 using AudioManager = Scripts.Audio.AudioManager;
+using GameSettings = Scripts.Game.GameSettings;
 
 namespace Scripts.MainMenu
 {
@@ -82,6 +83,7 @@ namespace Scripts.MainMenu
         {
             _musicSlider.value = Mathf.RoundToInt((AudioManager.Instance.musicSource.volume)*100);
             _sfxSlider.value = Mathf.RoundToInt((AudioManager.Instance.sfxSource.volume) * 100);
+            _cameraSensitivitySlider.value = Mathf.RoundToInt((GameSettings.Instance.CameraSensitivity) * 100);
         }
         #endregion
 
@@ -116,7 +118,7 @@ namespace Scripts.MainMenu
         /// </summary>
         public void SetCameraSensitivity(float sensitivity)
         {
-
+            GameSettings.Instance.SetCameraSensitivity(sensitivity / 100);
         }
         #endregion
     }

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -14,9 +15,9 @@ namespace Scripts.MainMenu
         [SerializeField] private UIDocument _optionMenuDocument;
         public GameObject MainMenu;
         public GameObject OptionsMenu;
-        private Button _backButton, _applyChangesButton, _revertChangesButton;
+        private Button _backButton, _applyChangesButton, _revertChangesButton, _increaseNPCSubtitleSpeed, _decreaseNPCSubtitleSpeed;
         private SliderInt _musicSlider, _sfxSlider, _cameraSensitivitySlider;
-        private Label _musicVolumeLabel, _sfxVolumeLabel, __cameraSensitivityLabel;
+        private Label _musicVolumeLabel, _sfxVolumeLabel, _cameraSensitivityLabel, _npcSubtitleSpeedLabel;
         #endregion
 
         #region Enable Methods
@@ -43,6 +44,9 @@ namespace Scripts.MainMenu
             _applyChangesButton = root.Q<Button>("ApplyChangesButton");
             _revertChangesButton = root.Q<Button>("RevertChangesButton");
 
+            _increaseNPCSubtitleSpeed = root.Q<Button>("IncreaseNPCSubtitleSpeed");
+            _decreaseNPCSubtitleSpeed = root.Q<Button>("DecreaseNPCSubtitleSpeed");
+
             //Set slider fields
             _musicSlider = root.Q<SliderInt>("MusicSlider");
             _sfxSlider = root.Q<SliderInt>("SFXSlider");
@@ -51,7 +55,8 @@ namespace Scripts.MainMenu
             //Set slider labels
             _musicVolumeLabel = root.Q<Label>("MusicVolumeLabel");
             _sfxVolumeLabel = root.Q<Label>("SFXVolumeLabel");
-            __cameraSensitivityLabel = root.Q<Label>("CameraSensitivityLabel");
+            _cameraSensitivityLabel = root.Q<Label>("CameraSensitivityLabel");
+            _npcSubtitleSpeedLabel = root.Q<Label>("NPCSubtitleSpeedLabel");
         }
 
         /// <summary>
@@ -63,10 +68,14 @@ namespace Scripts.MainMenu
             _backButton.clickable.clicked += GoBack;
             _applyChangesButton.clickable.clicked += UpdateSettings;
             _revertChangesButton.clickable.clicked += RevertSettingsChanges;
+
+            _increaseNPCSubtitleSpeed.clickable.clicked += IncreaseNPCSubtitleSpeed;
+            _decreaseNPCSubtitleSpeed.clickable.clicked += DecreaseNPCSubtitleSpeed;
+
             //set slider methods
             _musicSlider.RegisterValueChangedCallback(value => UpdateSliderValue(value.newValue, _musicVolumeLabel));
             _sfxSlider.RegisterValueChangedCallback(value => UpdateSliderValue(value.newValue, _sfxVolumeLabel));
-            _cameraSensitivitySlider.RegisterValueChangedCallback(value => UpdateSliderValue(value.newValue, __cameraSensitivityLabel));
+            _cameraSensitivitySlider.RegisterValueChangedCallback(value => UpdateSliderValue(value.newValue, _cameraSensitivityLabel));
         }
 
         /// <summary>
@@ -80,7 +89,25 @@ namespace Scripts.MainMenu
 
             _musicVolumeLabel.text = _musicSlider.value.ToString();
             _sfxVolumeLabel.text = _sfxSlider.value.ToString();
-            __cameraSensitivityLabel.text = _cameraSensitivitySlider.value.ToString();
+            _cameraSensitivityLabel.text = _cameraSensitivitySlider.value.ToString();
+            _npcSubtitleSpeedLabel.text = Math.Round(GameSettings.Instance.NPCSubtitleSpeed, 1).ToString();
+            CheckEnabledNPCSubtitleSpeedButtons();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void CheckEnabledNPCSubtitleSpeedButtons()
+        {
+            float speed = float.Parse(_npcSubtitleSpeedLabel.text);
+            if (speed == 1f)
+            {
+                _decreaseNPCSubtitleSpeed.SetEnabled(true);
+            }
+            if (speed == 10f)
+            {
+                _increaseNPCSubtitleSpeed.SetEnabled(true);
+            }
         }
         #endregion
 
@@ -109,11 +136,58 @@ namespace Scripts.MainMenu
         /// <summary>
         /// 
         /// </summary>
+        private void IncreaseNPCSubtitleSpeed()
+        {
+            float speed = float.Parse(_npcSubtitleSpeedLabel.text);
+            if(speed == 10f)
+            {
+                return;
+            }
+            if(speed == 1f)
+            {
+                _decreaseNPCSubtitleSpeed.SetEnabled(true);
+            }
+            speed += 0.5f;
+            _npcSubtitleSpeedLabel.text = Math.Round(speed, 1).ToString();
+            if(speed == 10f)
+            {
+                _increaseNPCSubtitleSpeed.SetEnabled(false);
+            }
+            EnableApplyRevertButtons();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void DecreaseNPCSubtitleSpeed()
+        {
+            float speed = float.Parse(_npcSubtitleSpeedLabel.text);
+            if (speed == 1f)
+            {
+                return;
+            }
+            if (speed == 10f)
+            {
+                _increaseNPCSubtitleSpeed.SetEnabled(true);
+            }
+            speed -= 0.5f;
+            _npcSubtitleSpeedLabel.text = Math.Round(speed, 1).ToString();
+            if (speed == 1f)
+            {
+                _decreaseNPCSubtitleSpeed.SetEnabled(false);
+            }
+            EnableApplyRevertButtons();
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
         private void UpdateSettings()
         {
             SetMusicValue(_musicSlider.value);
             SetSFXValue(_sfxSlider.value);
             SetCameraSensitivity(_cameraSensitivitySlider.value);
+            SetNPCSubtitleSpeed(float.Parse(_npcSubtitleSpeedLabel.text));
             DisableApplyRevertButtons();
         }
 
@@ -168,6 +242,11 @@ namespace Scripts.MainMenu
         public void SetCameraSensitivity(float sensitivity)
         {
             GameSettings.Instance.SetCameraSensitivity(sensitivity / 100);
+        }
+
+        public void SetNPCSubtitleSpeed(float speed)
+        {
+            GameSettings.Instance.SetNPCSubtitleSpeed(speed);
         }
         #endregion
     }

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -255,7 +255,7 @@ namespace Scripts.MainMenu
 
         public void SetNPCSubtitleSpeed(float speed)
         {
-            GameSettings.Instance.SetNPCSubtitleSpeed(speed);
+            GameSettings.Instance.SetNPCSubtitleSpeed(speed/100);
         }
         #endregion
     }

--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -14,7 +14,7 @@ namespace Scripts.MainMenu
         public GameObject MainMenu;
         public GameObject OptionsMenu;
         private Button _backButton;
-        private Slider _musicSlider, _sfxSlider, _cameraSensitivitySlider;
+        private SliderInt _musicSlider, _sfxSlider, _cameraSensitivitySlider;
         #endregion
 
         #region Enable Methods
@@ -39,9 +39,9 @@ namespace Scripts.MainMenu
             _backButton = root.Q<Button>("BackButton");
 
             //set slider fields
-            _musicSlider = root.Q<Slider>("MusicSlider");
-            _sfxSlider = root.Q<Slider>("SFXSlider");
-            _cameraSensitivitySlider = root.Q<Slider>("CameraSensitivitySlider");
+            _musicSlider = root.Q<SliderInt>("MusicSlider");
+            _sfxSlider = root.Q<SliderInt>("SFXSlider");
+            _cameraSensitivitySlider = root.Q<SliderInt>("CameraSensitivitySlider");
         }
 
         /// <summary>
@@ -51,6 +51,28 @@ namespace Scripts.MainMenu
         {
             //set button clicked methods
             _backButton.clickable.clicked += GoBack;
+
+            //set slider methods
+            _musicSlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetMusicValue));
+            _sfxSlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetMusicValue));
+            _cameraSensitivitySlider.RegisterValueChangedCallback(value => HandleSliderChange(value.newValue, SetMusicValue));
+        }
+
+        /// <summary>
+        /// From Google AI Overview: In C#, a delegate is a type that acts as a reference to a method with a specific parameter list and return type.
+        /// </summary>
+        private delegate void SetSliderValueFunction(float value = -1);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        private void HandleSliderChange(float value, SetSliderValueFunction function)
+        {
+            if(value != -1 && function != null)
+            {
+                function(value);
+            }
+            
         }
 
         /// <summary>
@@ -58,8 +80,8 @@ namespace Scripts.MainMenu
         /// </summary>
         private void SetSliderValues()
         {
-            _musicSlider.value = AudioManager.Instance.musicSource.volume;
-            _sfxSlider.value = AudioManager.Instance.sfxSource.volume;
+            _musicSlider.value = Mathf.RoundToInt((AudioManager.Instance.musicSource.volume)*100);
+            _sfxSlider.value = Mathf.RoundToInt((AudioManager.Instance.sfxSource.volume) * 100);
         }
         #endregion
 
@@ -76,28 +98,24 @@ namespace Scripts.MainMenu
         /// <summary>
         /// 
         /// </summary>
-        public void SetSFXValue()
+        public void SetSFXValue(float volume)
         {
-            float volume = _sfxSlider.value;
             AudioManager.Instance.sfxSource.volume = volume / 100;
         }
 
         /// <summary>
         /// 
         /// </summary>
-        public void SetMusicValue()
+        public void SetMusicValue(float volume)
         {
-            float volume = _musicSlider.value;
             AudioManager.Instance.musicSource.volume = volume / 100;
-
         }
 
         /// <summary>
         /// 
         /// </summary>
-        public void SetCameraSensitivity()
+        public void SetCameraSensitivity(float sensitivity)
         {
-            float sensitivity = _cameraSensitivitySlider.value;
 
         }
         #endregion

--- a/Assets/Scripts/NPC/NPCTrigger.cs
+++ b/Assets/Scripts/NPC/NPCTrigger.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using TMPro;
 using System.Collections;
+using Scripts.Game;
 
 public class NPCTrigger : MonoBehaviour
 {
@@ -23,6 +24,15 @@ public class NPCTrigger : MonoBehaviour
         if (textComponent == null)
         {
             Debug.LogError("TextMeshPro component not found on bubbleText GameObject.");
+        }
+        //set NPC SubtitleSpeed
+        if (GameSettings.Instance != null)
+        {
+            typeWritingSpeed = GameSettings.Instance.NPCSubtitleSpeed;
+        }
+        else
+        {
+            Debug.LogError("GameSettings is null");
         }
     }
     /// <summary>

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using PlayerLocomotionInput = Scripts.Player.Input.PlayerLocomotionInput;
 using PlayerActionInput = Scripts.Player.Input.PlayerActionInput;
+using GameSettings = Scripts.Game.GameSettings;
 
 namespace Scripts.Player
 {
@@ -64,6 +65,17 @@ namespace Scripts.Player
             _stepOffset = _characterController.stepOffset;
             //set anitBump to fasted possible speed
             _antiBump = sprintSpeed;
+
+            //set Camera Sensitvity
+            if(GameSettings.Instance != null)
+            {
+                lookSensitivityH = GameSettings.Instance.CameraSensitivity;
+                lookSensitivityV = GameSettings.Instance.CameraSensitivity;
+            }
+            else
+            {
+                Debug.LogError("GameSettings is null");
+            }
         }
         #endregion
 

--- a/Assets/UI Toolkit/MainMenu.uxml
+++ b/Assets/UI Toolkit/MainMenu.uxml
@@ -5,8 +5,8 @@
             <ui:Label tabindex="-1" text="Main Menu" display-tooltip-when-elided="true" style="font-size: 75px; -unity-font-style: bold; -unity-text-align: upper-center;" />
             <ui:VisualElement name="ButtonContainer" style="flex-grow: 1; align-items: center; justify-content: center;">
                 <ui:Button text="Play" display-tooltip-when-elided="true" name="PlayButton" class="MenuButton playButton" />
-                <ui:Button text="Settings" display-tooltip-when-elided="true" name="SettingButton" class="MenuButton playButton" />
-                <ui:Button text="Quit" display-tooltip-when-elided="true" name="QuitButton" class="MenuButton playButton" />
+                <ui:Button text="Options" display-tooltip-when-elided="true" name="SettingButton" class="MenuButton playButton" />
+                <ui:Button text="Tutorial" display-tooltip-when-elided="true" name="TutorialButton" class="MenuButton playButton" />
             </ui:VisualElement>
         </ui:VisualElement>
     </ui:VisualElement>

--- a/Assets/UI Toolkit/OptionMenu.uxml
+++ b/Assets/UI Toolkit/OptionMenu.uxml
@@ -3,23 +3,30 @@
         <ui:VisualElement name="OptionsContainer" style="flex-grow: 1; width: 1920px; height: 1080px; align-self: flex-start;">
             <ui:Button text="Back" display-tooltip-when-elided="true" name="BackButton" style="align-items: auto; width: 450px; height: 120px; font-size: 32px; -unity-font-style: bold;" />
             <ui:Label tabindex="-1" text="Option Menu" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-            <ui:VisualElement name="SoundSettings" style="flex-grow: 1;">
-                <ui:Label tabindex="-1" text="Sound Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-                <ui:SliderInt label="Music" value="42" high-value="100" name="MusicSlider" style="width: 900px;" />
-                <ui:SliderInt label="SFX" value="42" high-value="100" name="SFXSlider" style="width: 900px;" />
-            </ui:VisualElement>
-            <ui:VisualElement name="CameraSettings" style="flex-grow: 1;">
-                <ui:Label tabindex="-1" text="Camera Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-                <ui:SliderInt label="SliderInt" value="42" high-value="100" name="CameraSensitivitySlider" style="width: 900px;" />
-            </ui:VisualElement>
-            <ui:VisualElement name="NPCSettings" style="flex-grow: 1;">
-                <ui:Label tabindex="-1" text="NPC Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-                <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                    <ui:Button text="Button" display-tooltip-when-elided="true" name="Button" style="width: 500px;" />
-                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" style="width: 500px;" />
-                    <ui:Button text="Button" display-tooltip-when-elided="true" style="width: 500px;" />
+            <ui:ScrollView mode="Vertical">
+                <ui:VisualElement name="SoundSettings" style="flex-grow: 1;">
+                    <ui:Label tabindex="-1" text="Sound Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+                    <ui:SliderInt label="Music" value="42" high-value="100" name="MusicSlider" style="width: 900px;" />
+                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="MusicVolumeLabel" />
+                    <ui:SliderInt label="SFX" value="42" high-value="100" name="SFXSlider" style="width: 900px;" />
+                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="SFXVolumeLabel" />
                 </ui:VisualElement>
-            </ui:VisualElement>
+                <ui:VisualElement name="CameraSettings" style="flex-grow: 1;">
+                    <ui:Label tabindex="-1" text="Camera Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+                    <ui:SliderInt label="SliderInt" value="42" high-value="100" name="CameraSensitivitySlider" style="width: 900px;" />
+                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="CameraSensitivityLabel" />
+                </ui:VisualElement>
+                <ui:VisualElement name="NPCSettings" style="flex-grow: 1;">
+                    <ui:Label tabindex="-1" text="NPC Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+                    <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
+                        <ui:Button text="Button" display-tooltip-when-elided="true" name="Button" style="width: 500px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" style="width: 500px;" />
+                        <ui:Button text="Button" display-tooltip-when-elided="true" style="width: 500px;" />
+                    </ui:VisualElement>
+                </ui:VisualElement>
+                <ui:Button text="Applu" display-tooltip-when-elided="true" name="ApplyChangesButton" />
+                <ui:Button text="Revert" display-tooltip-when-elided="true" name="RevertChangesButton" />
+            </ui:ScrollView>
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/UI Toolkit/OptionMenu.uxml
+++ b/Assets/UI Toolkit/OptionMenu.uxml
@@ -1,8 +1,25 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <ui:VisualElement name="OptionsScreen" style="flex-grow: 1; border-left-color: rgb(9, 9, 9); border-right-color: rgb(9, 9, 9); border-top-color: rgb(9, 9, 9); border-bottom-color: rgb(9, 9, 9); background-color: rgb(172, 234, 98);">
+    <ui:VisualElement name="OptionsScreen" style="flex-grow: 1; border-left-color: rgb(9, 9, 9); border-right-color: rgb(9, 9, 9); border-top-color: rgb(9, 9, 9); border-bottom-color: rgb(9, 9, 9); background-color: rgb(172, 234, 98); width: auto; height: auto;">
         <ui:VisualElement name="OptionsContainer" style="flex-grow: 1; width: 1920px; height: 1080px; align-self: flex-start;">
-            <ui:Label tabindex="-1" text="Option Menu" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
             <ui:Button text="Back" display-tooltip-when-elided="true" name="BackButton" style="align-items: auto; width: 450px; height: 120px; font-size: 32px; -unity-font-style: bold;" />
+            <ui:Label tabindex="-1" text="Option Menu" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+            <ui:VisualElement name="SoundSettings" style="flex-grow: 1;">
+                <ui:Label tabindex="-1" text="Sound Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+                <ui:SliderInt label="Music" value="42" high-value="100" name="MusicSlider" style="width: 900px;" />
+                <ui:SliderInt label="SFX" value="42" high-value="100" name="SFXSlider" style="width: 900px;" />
+            </ui:VisualElement>
+            <ui:VisualElement name="CameraSettings" style="flex-grow: 1;">
+                <ui:Label tabindex="-1" text="Camera Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+                <ui:SliderInt label="SliderInt" value="42" high-value="100" name="CameraSensitivitySlider" style="width: 900px;" />
+            </ui:VisualElement>
+            <ui:VisualElement name="NPCSettings" style="flex-grow: 1;">
+                <ui:Label tabindex="-1" text="NPC Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+                <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
+                    <ui:Button text="Button" display-tooltip-when-elided="true" name="Button" style="width: 500px;" />
+                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" style="width: 500px;" />
+                    <ui:Button text="Button" display-tooltip-when-elided="true" style="width: 500px;" />
+                </ui:VisualElement>
+            </ui:VisualElement>
         </ui:VisualElement>
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/UI Toolkit/OptionMenu.uxml
+++ b/Assets/UI Toolkit/OptionMenu.uxml
@@ -24,8 +24,8 @@
                         <ui:Button text="Button" display-tooltip-when-elided="true" style="width: 500px;" />
                     </ui:VisualElement>
                 </ui:VisualElement>
-                <ui:Button text="Applu" display-tooltip-when-elided="true" name="ApplyChangesButton" />
-                <ui:Button text="Revert" display-tooltip-when-elided="true" name="RevertChangesButton" />
+                <ui:Button text="Apply" display-tooltip-when-elided="true" name="ApplyChangesButton" focusable="true" />
+                <ui:Button text="Revert" display-tooltip-when-elided="true" name="RevertChangesButton" focusable="true" />
             </ui:ScrollView>
         </ui:VisualElement>
     </ui:VisualElement>

--- a/Assets/UI Toolkit/OptionMenu.uxml
+++ b/Assets/UI Toolkit/OptionMenu.uxml
@@ -1,40 +1,40 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <ui:VisualElement name="OptionsScreen" style="flex-grow: 1; border-left-color: rgb(9, 9, 9); border-right-color: rgb(9, 9, 9); border-top-color: rgb(9, 9, 9); border-bottom-color: rgb(9, 9, 9); background-color: rgb(172, 234, 98); width: auto; height: auto;">
         <ui:VisualElement name="OptionsContainer" style="flex-grow: 1; width: 1920px; height: 1080px; align-self: flex-start;">
-            <ui:Button text="Back" display-tooltip-when-elided="true" name="BackButton" style="align-items: auto; width: 450px; height: 120px; font-size: 32px; -unity-font-style: bold;" />
-            <ui:Label tabindex="-1" text="Option Menu" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+            <ui:Button text="Back" display-tooltip-when-elided="true" name="BackButton" style="align-items: auto; width: 350px; height: 100px; font-size: 32px; -unity-font-style: bold; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); margin-top: 20px; margin-left: 15px;" />
+            <ui:Label tabindex="-1" text="Option Menu" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold; -unity-text-align: upper-center; height: 92px; -unity-font-definition: url(&apos;project://database/Assets/TextMesh%20Pro/Fonts/LiberationSans.ttf?fileID=12800000&amp;guid=e3265ab4bf004d28a9537516768c1c75&amp;type=3#LiberationSans&apos;);" />
             <ui:ScrollView mode="Vertical">
                 <ui:VisualElement name="SoundSettings" style="flex-grow: 1;">
-                    <ui:Label tabindex="-1" text="Sound Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-                    <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                        <ui:SliderInt label="Music" value="42" high-value="100" name="MusicSlider" style="width: 900px;" />
-                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="MusicVolumeLabel" />
+                    <ui:Label tabindex="-1" text="Sound Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 49px; -unity-font-style: bold; margin-left: 25px; margin-top: 10px;" />
+                    <ui:VisualElement style="flex-grow: 1; flex-direction: row; -unity-text-align: upper-center; height: 54px; margin-left: 200px;">
+                        <ui:SliderInt label="Music" value="42" high-value="100" name="MusicSlider" style="width: 1400px; margin-left: 0; font-size: 23px; -unity-font-style: bold; justify-content: flex-start; align-self: auto; margin-top: 10px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="MusicVolumeLabel" style="font-size: 23px; margin-top: 10px; margin-left: 5px; -unity-font-style: bold;" />
                     </ui:VisualElement>
-                    <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                        <ui:SliderInt label="SFX" value="42" high-value="100" name="SFXSlider" style="width: 900px;" />
-                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="SFXVolumeLabel" />
+                    <ui:VisualElement style="flex-grow: 1; flex-direction: row; font-size: 23px; -unity-font-style: bold; margin-top: 10px; -unity-text-align: upper-left; margin-left: 200px;">
+                        <ui:SliderInt label="SFX" value="42" high-value="100" name="SFXSlider" style="width: 1400px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="SFXVolumeLabel" style="font-size: 23px;" />
                     </ui:VisualElement>
                 </ui:VisualElement>
                 <ui:VisualElement name="CameraSettings" style="flex-grow: 1;">
-                    <ui:Label tabindex="-1" text="Camera Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-                    <ui:VisualElement name="VisualElement" style="flex-grow: 1; flex-direction: row;">
-                        <ui:SliderInt label="SliderInt" value="42" high-value="100" name="CameraSensitivitySlider" style="width: 900px;" />
-                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="CameraSensitivityLabel" />
+                    <ui:Label tabindex="-1" text="Camera Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 49px; -unity-font-style: bold; margin-left: 25px;" />
+                    <ui:VisualElement name="VisualElement" style="flex-grow: 1; flex-direction: row; margin-left: 200px; margin-top: 10px;">
+                        <ui:SliderInt label="SliderInt" value="42" high-value="100" name="CameraSensitivitySlider" style="width: 1400px; -unity-font-style: bold; font-size: 23px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="CameraSensitivityLabel" style="font-size: 23px; -unity-font-style: bold;" />
                     </ui:VisualElement>
                 </ui:VisualElement>
                 <ui:VisualElement name="NPCSettings" style="flex-grow: 1;">
-                    <ui:Label tabindex="-1" text="NPC Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
+                    <ui:Label tabindex="-1" text="NPC Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 49px; -unity-font-style: bold; margin-left: 25px;" />
                     <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                        <ui:Label tabindex="-1" text="NPC Subtitle Speed" display-tooltip-when-elided="true" style="align-self: auto;" />
+                        <ui:Label tabindex="-1" text="NPC Subtitle Speed" display-tooltip-when-elided="true" style="align-self: auto; font-size: 23px; -unity-font-style: bold; margin-left: 30px; margin-top: 23px;" />
                         <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                            <ui:Button text="Button" display-tooltip-when-elided="true" name="DecreaseNPCSubtitleSpeed" style="width: 500px;" />
-                            <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="NPCSubtitleSpeedLabel" style="width: 500px; -unity-text-align: upper-center; font-size: 29px;" />
-                            <ui:Button text="Button" display-tooltip-when-elided="true" name="IncreaseNPCSubtitleSpeed" style="width: 500px;" />
+                            <ui:Button text="Button" display-tooltip-when-elided="true" name="DecreaseNPCSubtitleSpeed" style="width: 400px; margin-left: 25px; font-size: 25px; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); -unity-font-style: bold; height: 90px;" />
+                            <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="NPCSubtitleSpeedLabel" style="width: 500px; -unity-text-align: upper-center; font-size: 23px; -unity-font-style: bold;" />
+                            <ui:Button text="Button" display-tooltip-when-elided="true" name="IncreaseNPCSubtitleSpeed" style="width: 400px; font-size: 25px; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); -unity-font-style: bold; height: 90px;" />
                         </ui:VisualElement>
                     </ui:VisualElement>
                 </ui:VisualElement>
-                <ui:Button text="Apply" display-tooltip-when-elided="true" name="ApplyChangesButton" focusable="true" />
-                <ui:Button text="Revert" display-tooltip-when-elided="true" name="RevertChangesButton" focusable="true" />
+                <ui:Button text="Apply" display-tooltip-when-elided="true" name="ApplyChangesButton" focusable="true" style="width: 700px; margin-left: 600px; height: 100px; margin-top: 30px; font-size: 27px; -unity-font-style: bold; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117);" />
+                <ui:Button text="Revert" display-tooltip-when-elided="true" name="RevertChangesButton" focusable="true" style="width: 700px; height: 100px; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); font-size: 27px; -unity-font-style: bold; margin-top: 40px; margin-left: 600px;" />
             </ui:ScrollView>
         </ui:VisualElement>
     </ui:VisualElement>

--- a/Assets/UI Toolkit/OptionMenu.uxml
+++ b/Assets/UI Toolkit/OptionMenu.uxml
@@ -27,9 +27,9 @@
                     <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
                         <ui:Label tabindex="-1" text="NPC Subtitle Speed" display-tooltip-when-elided="true" style="align-self: auto; font-size: 23px; -unity-font-style: bold; margin-left: 30px; margin-top: 23px;" />
                         <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                            <ui:Button text="Button" display-tooltip-when-elided="true" name="DecreaseNPCSubtitleSpeed" style="width: 400px; margin-left: 25px; font-size: 25px; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); -unity-font-style: bold; height: 90px;" />
+                            <ui:Button text="-" display-tooltip-when-elided="true" name="DecreaseNPCSubtitleSpeed" style="width: 400px; margin-left: 25px; font-size: 50px; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); -unity-font-style: bold; height: 90px;" />
                             <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="NPCSubtitleSpeedLabel" style="width: 500px; -unity-text-align: upper-center; font-size: 23px; -unity-font-style: bold;" />
-                            <ui:Button text="Button" display-tooltip-when-elided="true" name="IncreaseNPCSubtitleSpeed" style="width: 400px; font-size: 25px; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); -unity-font-style: bold; height: 90px;" />
+                            <ui:Button text="+" display-tooltip-when-elided="true" name="IncreaseNPCSubtitleSpeed" style="width: 400px; font-size: 50px; border-top-left-radius: 32px; border-top-right-radius: 32px; border-bottom-right-radius: 32px; border-bottom-left-radius: 32px; background-color: rgb(217, 117, 117); -unity-font-style: bold; height: 90px;" />
                         </ui:VisualElement>
                     </ui:VisualElement>
                 </ui:VisualElement>

--- a/Assets/UI Toolkit/OptionMenu.uxml
+++ b/Assets/UI Toolkit/OptionMenu.uxml
@@ -6,23 +6,31 @@
             <ui:ScrollView mode="Vertical">
                 <ui:VisualElement name="SoundSettings" style="flex-grow: 1;">
                     <ui:Label tabindex="-1" text="Sound Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-                    <ui:SliderInt label="Music" value="42" high-value="100" name="MusicSlider" style="width: 900px;" />
-                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="MusicVolumeLabel" />
-                    <ui:SliderInt label="SFX" value="42" high-value="100" name="SFXSlider" style="width: 900px;" />
-                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="SFXVolumeLabel" />
+                    <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
+                        <ui:SliderInt label="Music" value="42" high-value="100" name="MusicSlider" style="width: 900px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="MusicVolumeLabel" />
+                    </ui:VisualElement>
+                    <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
+                        <ui:SliderInt label="SFX" value="42" high-value="100" name="SFXSlider" style="width: 900px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="SFXVolumeLabel" />
+                    </ui:VisualElement>
                 </ui:VisualElement>
                 <ui:VisualElement name="CameraSettings" style="flex-grow: 1;">
                     <ui:Label tabindex="-1" text="Camera Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
-                    <ui:SliderInt label="SliderInt" value="42" high-value="100" name="CameraSensitivitySlider" style="width: 900px;" />
-                    <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="CameraSensitivityLabel" />
+                    <ui:VisualElement name="VisualElement" style="flex-grow: 1; flex-direction: row;">
+                        <ui:SliderInt label="SliderInt" value="42" high-value="100" name="CameraSensitivitySlider" style="width: 900px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="CameraSensitivityLabel" />
+                    </ui:VisualElement>
                 </ui:VisualElement>
                 <ui:VisualElement name="NPCSettings" style="flex-grow: 1;">
                     <ui:Label tabindex="-1" text="NPC Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
                     <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                        <ui:Label tabindex="-1" text="NPC Subtitle Speed" display-tooltip-when-elided="true" />
-                        <ui:Button text="Button" display-tooltip-when-elided="true" name="DecreaseNPCSubtitleSpeed" style="width: 500px;" />
-                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="NPCSubtitleSpeedLabel" style="width: 500px;" />
-                        <ui:Button text="Button" display-tooltip-when-elided="true" name="IncreaseNPCSubtitleSpeed" style="width: 500px;" />
+                        <ui:Label tabindex="-1" text="NPC Subtitle Speed" display-tooltip-when-elided="true" style="align-self: auto;" />
+                        <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
+                            <ui:Button text="Button" display-tooltip-when-elided="true" name="DecreaseNPCSubtitleSpeed" style="width: 500px;" />
+                            <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="NPCSubtitleSpeedLabel" style="width: 500px; -unity-text-align: upper-center; font-size: 29px;" />
+                            <ui:Button text="Button" display-tooltip-when-elided="true" name="IncreaseNPCSubtitleSpeed" style="width: 500px;" />
+                        </ui:VisualElement>
                     </ui:VisualElement>
                 </ui:VisualElement>
                 <ui:Button text="Apply" display-tooltip-when-elided="true" name="ApplyChangesButton" focusable="true" />

--- a/Assets/UI Toolkit/OptionMenu.uxml
+++ b/Assets/UI Toolkit/OptionMenu.uxml
@@ -19,9 +19,10 @@
                 <ui:VisualElement name="NPCSettings" style="flex-grow: 1;">
                     <ui:Label tabindex="-1" text="NPC Settings" display-tooltip-when-elided="true" name="Title" style="align-items: center; justify-content: center; font-size: 72px; -unity-font-style: bold;" />
                     <ui:VisualElement style="flex-grow: 1; flex-direction: row;">
-                        <ui:Button text="Button" display-tooltip-when-elided="true" name="Button" style="width: 500px;" />
-                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" style="width: 500px;" />
-                        <ui:Button text="Button" display-tooltip-when-elided="true" style="width: 500px;" />
+                        <ui:Label tabindex="-1" text="NPC Subtitle Speed" display-tooltip-when-elided="true" />
+                        <ui:Button text="Button" display-tooltip-when-elided="true" name="DecreaseNPCSubtitleSpeed" style="width: 500px;" />
+                        <ui:Label tabindex="-1" text="Label" display-tooltip-when-elided="true" name="NPCSubtitleSpeedLabel" style="width: 500px;" />
+                        <ui:Button text="Button" display-tooltip-when-elided="true" name="IncreaseNPCSubtitleSpeed" style="width: 500px;" />
                     </ui:VisualElement>
                 </ui:VisualElement>
                 <ui:Button text="Apply" display-tooltip-when-elided="true" name="ApplyChangesButton" focusable="true" />


### PR DESCRIPTION
The option screen consists of various different settings the user can change within the game.  The option menu is split up into three parts ; Sound settings, Camera settings and NPC subtitle settings with the addition of 3 additional buttons; Back , Apply and Revert. The sound setting consists of two sliders one for Music and one for SFX value which allows to change volume for both categories. The camera setting also consists of a slider button which allows you to change the camera sensitivity. The NPC subtitle speed includes two buttons which allows you to increment the subtitle speed by 0.5 . All three settings shows the value. In addition a back button is included to go back to the main menu, an apply button to save settings and a revert button to reset settings to default.  


Closes #18 