### PR TITLE
Bug Fix Settings NPC Subtitle Speed

### DIFF
--- a/Assets/Scripts/MainMenu/OptionMenuScript.cs
+++ b/Assets/Scripts/MainMenu/OptionMenuScript.cs
@@ -90,7 +90,7 @@ namespace Scripts.MainMenu
             _musicVolumeLabel.text = _musicSlider.value.ToString();
             _sfxVolumeLabel.text = _sfxSlider.value.ToString();
             _cameraSensitivityLabel.text = _cameraSensitivitySlider.value.ToString();
-            _npcSubtitleSpeedLabel.text = Math.Round(GameSettings.Instance.NPCSubtitleSpeed, 1).ToString();
+            _npcSubtitleSpeedLabel.text = Math.Round((GameSettings.Instance.NPCSubtitleSpeed * 100), 1).ToString();
             CheckEnabledNPCSubtitleSpeedButtons();
         }
 


### PR DESCRIPTION
## Issue
NPC Subtitle Speed in our game is a value between 0.01s to 1s, however in the Settings Menu the Player sees the NPC Subtitle Speed as a value between 1 to 10 (which can be incremented and decremented by a value of 0.5). When testing the main branch a bug was found where the value displayed was outside the 1-10 range.

## Fix
When displaying the NPC Subtitle Speed Value initially (in method `SetInitialMenuComponentValues()`), the original Subtitle Speed needs to be times by 100. This will show the NPC Subtitle value as desired being in the range of 1-10.