### PR TITLE
Change Keyboard Walk Control

### DIFF
--- a/Assets/Input/PlayerControls.inputactions
+++ b/Assets/Input/PlayerControls.inputactions
@@ -335,7 +335,7 @@
                 {
                     "name": "",
                     "id": "84b968c2-14ca-453f-a2e3-eb4bdc6f8407",
-                    "path": "<Keyboard>/leftCtrl",
+                    "path": "<Keyboard>/c",
                     "interactions": "",
                     "processors": "",
                     "groups": "Keyboard&Mouse",


### PR DESCRIPTION
## Changes
I have changed the keyboard binding to toggling (or holding to) walk to the key `C`. This fixes the bug where, when playing on a WebGL Build, the keybinding `CTRL + W` closes the current tab on Chrome.

## Issues Closing
Closes #75