### PR TITLE
Added Key Prompts To Walking NPC

### DIFF
--- a/Assets/Prefabs/GameScreen.prefab
+++ b/Assets/Prefabs/GameScreen.prefab
@@ -37,7 +37,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 160, y: 30}
+  m_SizeDelta: {x: 200, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3919482682581929438
 CanvasRenderer:
@@ -145,6 +145,7 @@ GameObject:
   - component: {fileID: 1221803505978622070}
   - component: {fileID: 8008871680515672718}
   - component: {fileID: 7326790841920498880}
+  - component: {fileID: 6182188775737605675}
   m_Layer: 5
   m_Name: GameScreen
   m_TagString: GameScreen
@@ -166,6 +167,7 @@ RectTransform:
   m_Children:
   - {fileID: 3242259836052724951}
   - {fileID: 16537542583181616}
+  - {fileID: 427342610564514892}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -236,6 +238,153 @@ MonoBehaviour:
   m_BlockingMask:
     serializedVersion: 2
     m_Bits: 4294967295
+--- !u!114 &6182188775737605675
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2432969861152675872}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d19cde145c7f54a7cbbdaceb264b7eca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _keyPromptTextField: {fileID: 7661519717944560272}
+--- !u!1 &3082536167790214029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8863326861944817564}
+  - component: {fileID: 4486686794986146824}
+  - component: {fileID: 2634163386334233678}
+  m_Layer: 5
+  m_Name: TextField
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8863326861944817564
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3082536167790214029}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 427342610564514892}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1000, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4486686794986146824
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3082536167790214029}
+  m_CullTransparentMesh: 1
+--- !u!114 &2634163386334233678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3082536167790214029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Press F Key To Continue
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 50
+  m_fontSizeBase: 50
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &4322791656461948888
 GameObject:
   m_ObjectHideFlags: 0
@@ -384,6 +533,7 @@ GameObject:
   - component: {fileID: 1092871254661393858}
   - component: {fileID: 958724463913539069}
   - component: {fileID: 6863269784104661081}
+  - component: {fileID: 1056118947793749234}
   m_Layer: 5
   m_Name: Pause Menu
   m_TagString: PauseMenu
@@ -494,6 +644,36 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3d7adffb4d008884fb7afa5a005b5ff6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1056118947793749234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6524069644594807802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4080268, g: 0.9245283, b: 0.3959772, a: 0.5176471}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &7129362922772559332
 GameObject:
   m_ObjectHideFlags: 0
@@ -628,3 +808,79 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7661519717944560272
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 427342610564514892}
+  - component: {fileID: 7478999924391887021}
+  - component: {fileID: 4384791806496849753}
+  m_Layer: 5
+  m_Name: KeyPromptTextFieldContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &427342610564514892
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7661519717944560272}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8863326861944817564}
+  m_Father: {fileID: 4408109173550771523}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 300}
+  m_SizeDelta: {x: 1000, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7478999924391887021
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7661519717944560272}
+  m_CullTransparentMesh: 1
+--- !u!114 &4384791806496849753
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7661519717944560272}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Scripts/Game/GameScreen.cs
+++ b/Assets/Scripts/Game/GameScreen.cs
@@ -1,0 +1,72 @@
+using System.Collections;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace Scripts.Game
+{
+    public class GameScreen : MonoBehaviour
+    {
+        #region Class Variables
+        private static GameScreen _instance;
+        public static GameScreen Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    Debug.LogError("GameScreen is Null");
+                }
+                return _instance;
+            }
+        }
+        [SerializeField] private GameObject _keyPromptTextField;
+
+        #endregion
+
+        #region Awake Methods
+        private void Awake()
+        {
+            SetInstance();
+        }
+        /// <summary>
+        /// Ensures only a single instance of the GameScreen class (and GameObject) is created.
+        /// </summary>
+        private void SetInstance()
+        {
+            if (_instance == null)
+            {
+                _instance = this;
+                DontDestroyOnLoad(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+        #endregion
+
+        #region Key Prompt Message Field Methods
+        /// <summary>
+        /// This method sets the sets the KeyPromptTextField GameObject to active (making the GameObject visible)
+        /// The method also sets the text (provided in the method arguement) to the KeyPromptTextField Game Object
+        /// </summary>
+        /// <param name="text"></param>
+        public void ShowKeyPrompt(string text)
+        {
+            _keyPromptTextField.SetActive(true);
+            TextMeshProUGUI textComponent = _keyPromptTextField.GetComponentInChildren<TextMeshProUGUI>();
+            textComponent.text = text;
+
+        }
+
+        /// <summary>
+        /// This method sets the sets the KeyPromptTextField GameObject to inactive (hiding the GameObject)
+        /// </summary>
+        public void HideKeyPrompt()
+        {
+            _keyPromptTextField.SetActive(false);
+        }
+        #endregion
+    }
+}

--- a/Assets/Scripts/Game/GameScreen.cs.meta
+++ b/Assets/Scripts/Game/GameScreen.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d19cde145c7f54a7cbbdaceb264b7eca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/NPC/WalkingNPCController.cs
+++ b/Assets/Scripts/NPC/WalkingNPCController.cs
@@ -16,7 +16,7 @@ namespace Scripts.NPC
     {
         #region Class Variables
         [HideInInspector] public bool istalkingToPlayer = false;
-        public List<string> NPCScript { get; set; } = new List<string>() { "Hello", "Good Bye" };
+        public List<string> NPCScript { get; set; } = new List<string>() { "Hello", "How Is Your Day", "Good Bye" };
         private int _scriptIndex = 0;
         private bool _coroutineActive = false;
         [SerializeField] private float _rotationSpeed = 3f;
@@ -69,7 +69,7 @@ namespace Scripts.NPC
                 //Disable Player Movement
                 _scriptIndex = 0;
                 _inTriggerBox = true;
-                GameScreen.Instance.ShowKeyPrompt("Press F Key To Continue");
+                GameScreen.Instance.ShowKeyPrompt("Press F Key To Talk To NPC");
             }
         }
 
@@ -114,6 +114,7 @@ namespace Scripts.NPC
             //Conditions (including pressing F Key) to start interaction with NPC
             if (_inTriggerBox && PlayerManager.Instance.CheckPlayerIsFacingTarget(_npcLayerMask) && PlayerManager.Instance.getTaskAccepted() && _scriptIndex == 0)
             {
+                GameScreen.Instance.HideKeyPrompt();
                 istalkingToPlayer = true;
                 PlayerManager.Instance.DisablePlayerMovement();
                 HandleNPCConversation();
@@ -233,6 +234,7 @@ _rotationSpeed * Time.deltaTime);
         {
             //start of dialouge (single line from script)
             _coroutineActive = true;
+            GameScreen.Instance.HideKeyPrompt();
             yield return StartCoroutine(TypeText());
             _scriptIndex += 1;
             //The condition that the NPC no longer has any more lines in its script to say to the player
@@ -240,6 +242,11 @@ _rotationSpeed * Time.deltaTime);
             {
                 istalkingToPlayer = false;
                 PlayerManager.Instance.EnablePlayerMovement();
+                GameScreen.Instance.HideKeyPrompt();
+            }
+            else
+            {
+                GameScreen.Instance.ShowKeyPrompt("Press F Key To Continue");
             }
             //end of dialouge (single line from script)
             _coroutineActive = false;

--- a/Assets/Scripts/NPC/WalkingNPCController.cs
+++ b/Assets/Scripts/NPC/WalkingNPCController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Scripts.MissonLogMenu;
 using UnityEngine;
 using PlayerManager = Scripts.Player.Player;
+using Scripts.Game;
 
 
 namespace Scripts.NPC
@@ -68,6 +69,7 @@ namespace Scripts.NPC
                 //Disable Player Movement
                 _scriptIndex = 0;
                 _inTriggerBox = true;
+                GameScreen.Instance.ShowKeyPrompt("Press F Key To Continue");
             }
         }
 
@@ -85,6 +87,7 @@ namespace Scripts.NPC
                 //enable player movement
                 istalkingToPlayer = false;
                 _inTriggerBox = false;
+                GameScreen.Instance.HideKeyPrompt();
             }
         }
         #endregion


### PR DESCRIPTION
## Changes

### GameScreen
The `GameScreen.cs` is a singleton class, making the `GameScreen` Game object accessible to any script in our game. This makes screen manipulation and access more accessible for different GameObjects and Classes. Inside the `GameScreen` GameObject, I have added a GameObject called `KeyPromptTextField`, which contains a Text UI GameObject intended for storing and displaying key prompt text to users. 

The script can complete two functionalities: to show the `KeyPromptTextField` GameObject, which activates the GameObject and displays a new set of text to the user, and to hide the the `KeyPromptTextField` GameObject, which inactivates the GameObject, disabling its visibility.


### Walking NPC
The WalkingNPCController.cs is the first class to integrate these changes. The class now indicates to the user to press the F key to talk and cycle through the dialogue of the walking NPC.


## Future Changes
The design of the KeyPrompt is primitive, with the intention of making it easy to view for now. We can improve the design later with the potential use of third-party assets. 

This issue can also be repurposed as a generalised visual text display for the game (with different use cases for displaying the text on screen, all utilising a single Text UI GameObject).

## Issues Closing
Closes #95