### PR TITLE
Change Garbage Detonation Button Interaction

### DIFF
--- a/Assets/Prefabs/GameScreen.prefab
+++ b/Assets/Prefabs/GameScreen.prefab
@@ -2818,7 +2818,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 39.445984, y: -23.944061}
+  m_AnchoredPosition: {x: 39.445984, y: -23.944092}
   m_SizeDelta: {x: -240.28, y: -195.425}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7867619047886058790
@@ -3391,10 +3391,10 @@ MonoBehaviour:
   m_Transition: 1
   m_Colors:
     m_NormalColor: {r: 1, g: 0, b: 0, a: 1}
-    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_HighlightedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_PressedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_SelectedColor: {r: 1, g: 0, b: 0, a: 1}
+    m_DisabledColor: {r: 1, g: 0, b: 0, a: 0.5019608}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -3408,7 +3408,7 @@ MonoBehaviour:
     m_PressedTrigger: Pressed
     m_SelectedTrigger: Selected
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 4587815627868019171}
   m_OnClick:
     m_PersistentCalls:

--- a/Assets/Scripts/GarbageDisposal/GarbageDisposalController.cs
+++ b/Assets/Scripts/GarbageDisposal/GarbageDisposalController.cs
@@ -5,6 +5,7 @@ using Scripts.Game;
 using Scripts.Quests;
 using UnityEngine.UI;
 using Scripts.Audio;
+using PlayerManager = Scripts.Player.Player;
 
 namespace Scripts.GarbageDisposal
 {
@@ -25,29 +26,24 @@ namespace Scripts.GarbageDisposal
 
         #region Start Methods
         /// <summary>
-        /// Start Method Gets a reference to the Garbage Detonate Button and if found it sets its on click method
-        /// The method also gets the audio source component
+        /// Start Method Gets a reference to the Garbage Detonate Button
         /// </summary>
         private void Start()
         {
             _garbageDetonateButton = GetGarbageDetonateButton();
-
-            if (_garbageDetonateButton != null)
-            {
-                _garbageDetonateButton.GetComponent<Button>().onClick.AddListener(HandleGarbageDisposal);
-            }
         }
         #endregion
-
-
+        
         #region Update
         /// <summary>
-        /// Update Methods handles either two conditons
+        /// Update Method handles Player Interaction with the Detonation Button
+        /// If the Button is pressed two conditions are handled
         /// Update method sets a timer for when the plasma is activated, after a certain time the player will lose the game
         /// Update method sets a timer for when the items have been launched. After 5s there are deleted from the game
         /// </summary>
         public void Update()
         {
+            //Handle Plasma Condition
             if (_plasmaActivated)
             {
                 _timer += Time.deltaTime;
@@ -57,6 +53,7 @@ namespace Scripts.GarbageDisposal
                     _plasmaActivated = false;
                 }
             }
+            //Handle Garbaged Launched
             else if (_itemsLaunched)
             {
                 _timer += Time.deltaTime;
@@ -64,6 +61,14 @@ namespace Scripts.GarbageDisposal
                 { 
                     _itemsLaunched = false;
                     DeleteGarbageItems();
+                }
+            }
+            //Handle Player Interaction With Detonation Button
+            else
+            {
+                if (_garbageDetonateButton.activeInHierarchy && PlayerManager.Instance.getTaskAccepted())
+                {
+                    HandleGarbageDisposal();
                 }
             }
         }

--- a/Assets/Scripts/GarbageDisposal/GarbageDisposalController.cs
+++ b/Assets/Scripts/GarbageDisposal/GarbageDisposalController.cs
@@ -43,7 +43,7 @@ namespace Scripts.GarbageDisposal
         /// </summary>
         public void Update()
         {
-            //Handle Plasma Condition
+            //Handle Plasma Explosion Condition
             if (_plasmaActivated)
             {
                 _timer += Time.deltaTime;
@@ -53,7 +53,7 @@ namespace Scripts.GarbageDisposal
                     _plasmaActivated = false;
                 }
             }
-            //Handle Garbaged Launched
+            //Handle Garbaged Launched Condition
             else if (_itemsLaunched)
             {
                 _timer += Time.deltaTime;

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,7 +8,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/StartScene.unity
     guid: 304015d8ed9d74035b3d034046470a75
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/GameScene.unity
     guid: 83f7f0e93b3cd4513a07c3273fc6d6b8
   m_configObjects:


### PR DESCRIPTION
## Implementation

The option to handle the Garbage Disposal in our game has changed. The on-screen UI Button is no longer interactable via the mouse cursor as we would like to keep mouse interactions during active gameplay focused on camera movement. To interact with the "Do Not Press" Garbage Disposal button the Player can press the F key. This is inline with the concept of the F key being the "Task Acceptance" key binding in our game.

## Issues Closing
Closing #122