### PR TITLE
Item Drop Bug Fix

### DIFF
--- a/Assets/Prefabs/Garbage Disposal.prefab
+++ b/Assets/Prefabs/Garbage Disposal.prefab
@@ -19951,7 +19951,7 @@ GameObject:
   - component: {fileID: 180556123503665910}
   - component: {fileID: 2527798851044681728}
   - component: {fileID: 6390893056672411964}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: Garbage Disposal
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -4045,7 +4045,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5004936183849925211, guid: 4c759055e2c63b54bb60680e5a2b1f73, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -23.944122
+      value: -23.944092
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4198,11 +4198,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5238017322281809905, guid: 13be02622dbee41a4a534b12c0f25dfa, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.41
+      value: 0.71
       objectReference: {fileID: 0}
     - target: {fileID: 5238017322281809905, guid: 13be02622dbee41a4a534b12c0f25dfa, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 19
+      value: 18.97
       objectReference: {fileID: 0}
     - target: {fileID: 5238017322281809905, guid: 13be02622dbee41a4a534b12c0f25dfa, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scripts/Item/DynamiteItem.cs
+++ b/Assets/Scripts/Item/DynamiteItem.cs
@@ -45,7 +45,10 @@ namespace Scripts.Item
         /// </summary>
         public void OnDisable()
         {
-            GameScreen.Instance?.HideKeyPrompt();
+            if (GameScreen.Instance != null)
+            {
+                GameScreen.Instance.HideKeyPrompt();
+            }
         }
         #endregion
 

--- a/Assets/Scripts/Item/DynamiteItem.cs
+++ b/Assets/Scripts/Item/DynamiteItem.cs
@@ -45,10 +45,7 @@ namespace Scripts.Item
         /// </summary>
         public void OnDisable()
         {
-            if (GameManager.Instance.HasGameEnded == false)
-            {
-                GameScreen.Instance.HideKeyPrompt();
-            }
+            GameScreen.Instance.HideKeyPrompt();
         }
         #endregion
 

--- a/Assets/Scripts/Item/DynamiteItem.cs
+++ b/Assets/Scripts/Item/DynamiteItem.cs
@@ -45,7 +45,7 @@ namespace Scripts.Item
         /// </summary>
         public void OnDisable()
         {
-            GameScreen.Instance.HideKeyPrompt();
+            GameScreen.Instance?.HideKeyPrompt();
         }
         #endregion
 

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -408,7 +408,9 @@ namespace Scripts.Player
 
             Vector3 dropPosition = transform.position + transform.forward * 2f;
 
-            if (Physics.Raycast(transform.position, transform.forward, out RaycastHit hit, 1f))
+            int layerMask = ~LayerMask.GetMask("GarbageDisposal");
+
+            if (Physics.Raycast(transform.position, transform.forward, out RaycastHit hit, 1f, layerMask))
             {
                 dropPosition = transform.position - transform.forward * 2f;
             }

--- a/Assets/Scripts/Player/Player.cs
+++ b/Assets/Scripts/Player/Player.cs
@@ -391,7 +391,9 @@ namespace Scripts.Player
         }
 
         /// <summary>
-        /// This is the function called to instantiate items from the inventory back into the world
+        /// This is the function called to instantiate items from the inventory back into the world, it also
+        /// checks for if the item is a GPS Scanner, and if such deactivates the Radar UI.
+        /// Checks for obstacles infront of the player, placing items behind the player if there is an object in the way
         /// </summary>
         public void DropItem(ItemPickup item)
         {
@@ -403,9 +405,14 @@ namespace Scripts.Player
             }
 
             RemoveItem(item);
-            
 
             Vector3 dropPosition = transform.position + transform.forward * 2f;
+
+            if (Physics.Raycast(transform.position, transform.forward, out RaycastHit hit, 1f))
+            {
+                dropPosition = transform.position - transform.forward * 2f;
+            }
+
             item.gameObject.transform.position = dropPosition;
             item.gameObject.SetActive(true);
         }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -25,7 +25,7 @@ TagManager:
   - UI
   - Player
   - Item
-  - 
+  - GarbageDisposal
   - 
   - 
   - 


### PR DESCRIPTION
### Description

Addressed a bug where items dropped from the player's inventory could clip into objects such as terrain, walls, or other obstacles if dropped too close to them. To resolve this issue, a short forward raycast is performed to detect objects in front of the player. If an object is detected, the item is dropped behind the player instead of in front.

### Changes Implemented
**Raycast Detection:**

- Added a raycast in the DropItem method of Player.cs to check for any object within a short distance in front of the player
- If an object is detected, the item drop position is adjusted to be behind the player.
- Ensures items do not clip into or become inaccessible due to obstacles.
- Items will reliably drop in accessible locations regardless of the player's proximity to walls or terrain.

_**Additional**_

Removed redundant code in DynamiteItem.cs script for OnDisable method

Closes #115 